### PR TITLE
Fix broken link

### DIFF
--- a/announcements/2017-08-04_additional_regions.md
+++ b/announcements/2017-08-04_additional_regions.md
@@ -16,7 +16,7 @@ The following regions are available under a feature flag and needs subscription 
 1. Korea South
 2. Korea Central
 
-See the previous [announcement](announcements/2017-06-28-acs-uk-public-preview.md) for new features.
+See the previous [announcement](/2017-06-28-acs-uk-public-preview.md) for new features.
 
 New functionality in the regions uksouth and ukwest can be deployed using the Azure CLI 2.0  version 2.0.12 which can be 
 downloaded [here](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)


### PR DESCRIPTION
The "previous announcement" link is broken.  I has announcements in the path twice.